### PR TITLE
Fix callback routing for an auth provider

### DIFF
--- a/src/routes/auth/callback/google/+server.js
+++ b/src/routes/auth/callback/google/+server.js
@@ -1,0 +1,1 @@
+export const prerender = false


### PR DESCRIPTION
What I'm finding is that according to

https://github.com/sveltejs/kit/blob/32c0acc373bfcd22ef1c544af25950a91c5c30a9/packages/kit/src/runtime/server/respond.js

there needs to be a route defined for it to reach the line that populates the `event.platform` attribute with the local emulated cloudflare adapter.

Creating this api/server route appears to be sufficient in allowing the auth callback to proceed. I'm not sure if there's perhaps a more efficient/idiomatic way in sveltekit/authjs to handle what this does without explicitly creating the "dummy" route.